### PR TITLE
Update lodash.indexBy to lodash.keyBy

### DIFF
--- a/src/js/controllers/addresses.js
+++ b/src/js/controllers/addresses.js
@@ -38,7 +38,7 @@ angular.module('copayApp.controllers').controller('addressesController', functio
         }
 
         withBalance = resp.byAddress;
-        var idx = lodash.indexBy(withBalance, 'address');
+        var idx = lodash.keyBy(withBalance, 'address');
         $scope.noBalance = lodash.reject(allAddresses, function(x) {
           return idx[x.address];
         });

--- a/src/js/controllers/preferencesAltCurrency.js
+++ b/src/js/controllers/preferencesAltCurrency.js
@@ -16,8 +16,8 @@ angular.module('copayApp.controllers').controller('preferencesAltCurrencyControl
 
         $scope.listComplete = false;
 
-        var idx = lodash.indexBy(unusedCurrencyList, 'isoCode');
-        var idx2 = lodash.indexBy($scope.lastUsedAltCurrencyList, 'isoCode');
+        var idx = lodash.keyBy(unusedCurrencyList, 'isoCode');
+        var idx2 = lodash.keyBy($scope.lastUsedAltCurrencyList, 'isoCode');
 
         completeAlternativeList = lodash.reject(rateService.listAlternatives(true), function(c) {
           return idx[c.isoCode] || idx2[c.isoCode];

--- a/src/js/controllers/preferencesLogs.js
+++ b/src/js/controllers/preferencesLogs.js
@@ -7,7 +7,7 @@ angular.module('copayApp.controllers').controller('preferencesLogs',
     var logLevels = historicLog.getLevels();
     var selectedLevel;
 
-    $scope.logOptions = lodash.indexBy(logLevels, 'level');
+    $scope.logOptions = lodash.keyBy(logLevels, 'level');
 
     var filterLogs = function(weight) {
       $scope.filteredLogs = historicLog.get(weight);


### PR DESCRIPTION
Lodash deprecated indexBy and replaced it with keyBy. This commit
updates the copay code to use the updated function.

References #12 