### PR TITLE
This commit moves the fileicon to optional dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,6 @@
     "cordova-plugin-x-toast": "~2.5.2",
     "cordova-windows": "~5.0.0",
     "express": "^4.11.2",
-    "fileicon": "^0.2.0",
     "fs-extra": "^4.0.2",
     "grunt-angular-gettext": "^2.2.3",
     "grunt-browserify": "^5.0.0",
@@ -106,6 +105,9 @@
     "ionic-plugin-keyboard": "~2.2.1",
     "load-grunt-tasks": "^3.5.0",
     "shelljs": "^0.7.8"
+  },
+  "optionalDependencies": {
+    "fileicon": "^0.2.0"
   },
   "scripts": {
     "postinstall": "sed -i  -e \"s/.*require(...\\/...);//g\" node_modules/asn1.js-rfc5280/index.js; bower install",


### PR DESCRIPTION
Fileicon is a package that is only needed by MacOS. There for, if
we are unable to install the package, then we should still continue
with the npm install.