### PR TITLE
Upgrade ldoash sum method to sumBy

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "bezier-easing": "^2.0.3",
     "bhttp": "^1.2.4",
     "bitauth": "^0.2.1",
-    "bitcore-wallet-client-btcz": "git+https://github.com/bitcoinz-wallets/bitcore-wallet-client-btcz.git#v1.0.1",
+    "bitcore-wallet-client-btcz": "git+https://github.com/bitcoinz-wallets/bitcore-wallet-client-btcz.git#v1.0.2",
     "bower": "^1.7.9",
     "cordova": "^7.1.0",
     "cordova-android": "^6.4.0",

--- a/src/js/controllers/addresses.js
+++ b/src/js/controllers/addresses.js
@@ -77,7 +77,7 @@ angular.module('copayApp.controllers').controller('addressesController', functio
         if (resp && resp.allUtxos && resp.allUtxos.length) {
 
 
-          var allSum = lodash.sum(resp.allUtxos || 0, 'satoshis');
+          var allSum = lodash.sumBy(resp.allUtxos || 0, 'satoshis');
           var per = (resp.minFee / allSum) * 100;
 
           $scope.lowWarning = resp.warning;

--- a/src/js/services/walletService.js
+++ b/src/js/services/walletService.js
@@ -850,7 +850,6 @@ angular.module('copayApp.services').factory('walletService', function($log, $tim
     $log.debug('Creating address for wallet:', wallet.id);
 
     wallet.createAddress({}, function(err, addr) {
-      console.log('wallet.createAddress', err, addr);
       if (err) {
         var prefix = gettextCatalog.getString('Could not create address');
         if (err instanceof errors.CONNECTION_ERROR || (err.message && err.message.match(/5../))) {
@@ -948,7 +947,7 @@ angular.module('copayApp.services').factory('walletService', function($log, $tim
 
       var minFee = root.getMinFee(wallet, levels, resp.length);
 
-      var balance = lodash.sum(resp, 'satoshis');
+      var balance = lodash.sumBy(resp, 'satoshis');
 
       // for 2 outputs
       var lowAmount = root.getLowAmount(wallet, levels);
@@ -956,7 +955,7 @@ angular.module('copayApp.services').factory('walletService', function($log, $tim
         return x.satoshis < lowAmount;
       });
 
-      var totalLow = lodash.sum(lowUtxos, 'satoshis');
+      var totalLow = lodash.sumBy(lowUtxos, 'satoshis');
 
       return cb(err, {
         allUtxos: resp || [],


### PR DESCRIPTION
This commit fixes an issue with the usage of `sum`. The lodash
API has changed to use `sumBy` when specifing an identity.

References: https://github.com/bitcoinz-wallets/bitcoinz-copay-wallet/issues/20