### PR TITLE
Fix broken windows build

### DIFF
--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
     "fileicon": "^0.2.0"
   },
   "scripts": {
-    "postinstall": "sed -i  -e \"s/.*require(...\\/...);//g\" node_modules/asn1.js-rfc5280/index.js; bower install",
+    "postinstall": "sed -i  -e \"s/.*require(...\\/...);//g\" node_modules/asn1.js-rfc5280/index.js && bower install",
     "start": "npm run build:www && ionic serve --no-livereload --nogulp -s --address 0.0.0.0",
     "start:ios": "npm run build:www && npm run build:ios && npm run open:ios",
     "start:android": "npm run build:www && npm run build:android && npm run run:android",


### PR DESCRIPTION
Previously, npm would fail when installing packages, because the
postinstall task used a command that was not compatible with windows.
This commit fixes that broken command so that npm can install again!